### PR TITLE
follow rules by ITC to obtain the `ac_id`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitsrun"
 description = "A headless login and logout CLI for 10.0.0.55 at BIT"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/spencerwooo/bitsrun-rs"
@@ -42,6 +42,6 @@ pretty_env_logger = "0.5.0"
 strip = "symbols"
 
 [package.metadata.deb]
-copyright = "2023 Spencer Woo"
+copyright = "2024 Spencer Woo"
 maintainer-scripts = "debian/"
 systemd-units = { enable = true, start = false }


### PR DESCRIPTION
Resolves #11

Relates-to: https://github.com/BITNP/bitsrun/pull/49

### 已知的问题

#### 用了`or`而非`or_else`，有多余网络请求

无论是否登录，都会为了`ac_id`发送两个网络请求。

原因：`or_else`和`async`八字不合（[How to run async code within Option / Result function chain? - help - The Rust Programming Language Forum](https://users.rust-lang.org/t/how-to-run-async-code-within-option-result-function-chain/64053/4)），这样写更易理解。况且 Python 那边也有多余网络请求。

#### `ARBITRARY_HTTP_SITE`可能要换成校外网站

网信中心推荐 http://www.bit.edu.cn ，但我实测（`dbg!()`）发现每次都回落，并没起到效果。似乎换成校外网站（例如 http://b23.tv ）才会跳转。

```log
[src\client.rs:165:5] get_acid_by_url(client, ARBITRARY_HTTP_SITE).await = Err(
    failed to get ac_id from `http://www.bit.edu.cn/`,
)
[src\client.rs:168:13] get_acid_by_url(client, SRUN_PORTAL).await = Ok(
    "1",
)
```