### PR TITLE
Enable ANSI colors on supported Windows terminals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitsrun"
 description = "A headless login and logout CLI for 10.0.0.55 at BIT"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/spencerwooo/bitsrun-rs"
@@ -35,13 +35,14 @@ tabled = { version = "0.14", features = ["color"] }
 humansize = "2.1"
 chrono-humanize = "0.2"
 chrono = "0.4"
-log = "0.4.26"
-pretty_env_logger = "0.5.0"
+log = "0.4"
+pretty_env_logger = "0.5"
+enable-ansi-support = "0.2"
 
 [profile.release]
 strip = "symbols"
 
 [package.metadata.deb]
-copyright = "2024 Spencer Woo"
+copyright = "2025 Spencer Woo"
 maintainer-scripts = "debian/"
 systemd-units = { enable = true, start = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,10 @@ async fn main() {
 }
 
 async fn cli() -> Result<()> {
-    enable_ansi_support()?;
+    // disable ansi colors on non-supported windows terminals
+    if enable_ansi_support().is_err() {
+        owo_colors::set_override(false);
+    }
 
     let args = Arguments::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use clap::Parser;
 use cli::ClientArgs;
 use cli::StatusArgs;
+use enable_ansi_support::enable_ansi_support;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stderr;
 use owo_colors::Stream::Stdout;
@@ -37,6 +38,8 @@ async fn main() {
 }
 
 async fn cli() -> Result<()> {
+    enable_ansi_support()?;
+
     let args = Arguments::parse();
 
     // reusable http client


### PR DESCRIPTION
fixes #14