### PR TITLE
feat(docs): 中文 README 与 Windows 服务文档更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
 
 > [!NOTE]
 > Creating and starting the service requires Administrator privileges for proper Event Log source registration.
-> > Detailed guide: [`docs/windows-service.md`](docs/windows-service.md)
+> Detailed guide: [`docs/windows-service.md`](docs/windows-service.md)
 
 ## Config and credentials
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bitsrun
 
+English | [简体中文](README.zh-CN.md)
+
 [![GitHub Workflow Status (CI)](https://img.shields.io/github/actions/workflow/status/spencerwooo/bitsrun-rs/ci.yml?logo=github&label=ci&labelColor=%23223227)](https://github.com/spencerwooo/bitsrun-rs/actions/workflows/ci.yml)
 [![GitHub Workflow Status (Release)](https://img.shields.io/github/actions/workflow/status/spencerwooo/bitsrun-rs/release.yml?logo=github&label=release&labelColor=%23223227)](https://github.com/spencerwooo/bitsrun-rs/actions/workflows/release.yml)
 [![GitHub release](https://img.shields.io/github/v/release/spencerwooo/bitsrun-rs?logo=github&labelColor=%23223227)](https://github.com/spencerwooo/bitsrun-rs/releases/latest)
@@ -8,6 +10,7 @@
 🌐 A headless login and logout CLI for gateway (10.0.0.55) at BIT, now in Rust.
 
 ![CleanShot 2023-12-04 at 16 47 26@2x](https://github.com/spencerwooo/bitsrun-rs/assets/32114380/23343ba1-961c-41aa-b4b6-c09da93fb699)
+
 
 ## Install
 
@@ -71,6 +74,7 @@ $ bitsrun keep-alive
 
 > [!NOTE]
 > Use available system service managers to run `bitsrun keep-alive` as a daemon. (e.g., `systemd` for Linux, `launchd` for macOS, and Windows Service for Windows).
+> See [`docs/windows-service.md`](docs/windows-service.md) for Windows service setup.
 
 ## Available commands
 
@@ -96,6 +100,28 @@ Options:
 
 > [!TIP]
 > Use environment variable `NO_COLOR=true` to disable colored output.
+
+## Windows Service (Windows only)
+
+When launched by the Windows Service Control Manager (SCM), `bitsrun` runs the `keep-alive` daemon in service context and reports status to SCM. Logging goes to both Windows Event Log (source: `Bitsrun`) and a local file `bitsrun_service.log` next to the executable.
+
+Quick setup:
+
+```powershell
+sc.exe create Bitsrun binPath= "C:\Program Files\Bitsrun\bitsrun.exe" DisplayName= "Bitsrun" start= auto
+sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
+```
+
+- Place `bit-user.json` in the same directory as `bitsrun.exe` so the service can find it automatically.
+- Manage service: `sc.exe start Bitsrun`, `sc.exe stop Bitsrun`, `sc.exe query Bitsrun`
+- Remove service: `sc.exe stop Bitsrun` then `sc.exe delete Bitsrun`
+- Check logs:
+  - File: `bitsrun_service.log` beside `bitsrun.exe`
+  - Event Viewer → Windows Logs → Application → Source: `Bitsrun`
+
+> [!NOTE]
+> Creating and starting the service requires Administrator privileges for proper Event Log source registration.
+> > Detailed guide: [`docs/windows-service.md`](docs/windows-service.md)
 
 ## Config and credentials
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,8 +116,8 @@ sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
 }
 ```
 
-- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，如果你使用的设备是**普通终端**，请设为 `true` ！
-- `poll_interval`：守护进程轮询登录请求的间隔（秒），默认 `3600`
+- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，如果你使用的设备是**普通终端**，请设为 `true`
+- `poll_interval`：守护进程轮询登录请求的间隔（秒），默认为 `3600`
 
 Linux / macOS 上需将此文件权限设为 `600`，否则 `bitsrun` 将拒绝读取：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,137 @@
+# bitsrun
+
+[English](README.md) | 简体中文
+
+[![GitHub Workflow Status (CI)](https://img.shields.io/github/actions/workflow/status/spencerwooo/bitsrun-rs/ci.yml?logo=github&label=ci&labelColor=%23223227)](https://github.com/spencerwooo/bitsrun-rs/actions/workflows/ci.yml)
+[![GitHub Workflow Status (Release)](https://img.shields.io/github/actions/workflow/status/spencerwooo/bitsrun-rs/release.yml?logo=github&label=release&labelColor=%23223227)](https://github.com/spencerwooo/bitsrun-rs/actions/workflows/release.yml)
+[![GitHub release](https://img.shields.io/github/v/release/spencerwooo/bitsrun-rs?logo=github&labelColor=%23223227)](https://github.com/spencerwooo/bitsrun-rs/releases/latest)
+[![Crates.io](https://img.shields.io/crates/d/bitsrun?logo=rust&labelColor=%23223227&color=%23dec867)](https://crates.io/crates/bitsrun)
+
+🌐 北京理工大学（BIT）校园网网关（10.0.0.55）的无界面登录/登出 CLI（Rust 版）。
+
+如果你需要 Windows 服务方式运行守护进程，请阅读《Windows 服务设置》文档：[`docs/windows-service.zh-CN.md`](docs/windows-service.zh-CN.md)。
+
+## 安装
+
+- 一行安装（Linux / macOS，推荐）：`curl -fsSL https://cdn.jsdelivr.net/gh/spencerwooo/bitsrun-rs@main/install.sh | sh -`
+- Ubuntu / Debian（推荐，支持 `systemd`）：
+  - 从 [Releases](https://github.com/spencerwooo/bitsrun-rs/releases/latest) 下载最新 `.deb`
+  - `sudo apt install </path/to/file>.deb`
+  - 如需 `bitsrun.service`：编辑 `/lib/systemd/system/bitsrun.service` 指定绝对配置路径，然后 `sudo systemctl start bitsrun`
+- Cargo：`cargo install bitsrun`
+- 直接下载二进制：从 [Releases](https://github.com/spencerwooo/bitsrun-rs/releases/latest) 下载，`tar -xvf <file>.tar.gz` 解压后将 `bitsrun` 移动到 `PATH`
+
+## 使用
+
+登录或登出：
+
+```console
+$ bitsrun login -u <username> -p <password>
+bitsrun: <ip> (<username>) logged in
+
+$ bitsrun logout -u <username>
+bitsrun: <ip> logged out
+```
+
+查询设备登录状态：
+
+```console
+$ bitsrun status
+bitsrun: <ip> (<username>) is online
+┌────────────────┬───────────────┬───────────────┬─────────┐
+│ Traffic Used   │ Online Time   │ User Balance  │ Wallet  │
+├────────────────┼───────────────┼───────────────┼─────────┤
+│ 188.10 GiB     │ 2 months      │ 10.00         │ 0.00    │
+└────────────────┴───────────────┴───────────────┴─────────┘
+```
+
+保持会话存活：
+
+```console
+$ bitsrun keep-alive
+ INFO  bitsrun::daemon > starting daemon (<username>) with polling interval=3600s
+ INFO  bitsrun::daemon > <ip> (<username>): login success,
+ ...
+ ^C INFO  bitsrun::daemon > <username>: gracefully exiting
+```
+
+> 使用系统可用的服务管理器在后台运行 `bitsrun keep-alive`（例如 Linux 的 `systemd`、macOS 的 `launchd`，以及 Windows 的 Windows 服务）。Windows 服务详细见 [`docs/windows-service.zh-CN.md`](docs/windows-service.zh-CN.md)。
+
+## 可用命令
+
+```console
+$ bitsrun --help
+A headless login and logout CLI for 10.0.0.55 at BIT
+
+Usage: bitsrun [OPTIONS] [COMMAND]
+
+Commands:
+  login         Login to the campus network
+  logout        Logout from the campus network
+  status        Check device login status
+  config-paths  List all possible config file paths
+  keep-alive    Poll the server with login requests to keep the session alive
+  help          Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose  Verbose output
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+提示：设置环境变量 `NO_COLOR=true` 可禁用彩色输出。
+
+## Windows 服务（仅限 Windows）
+
+当由 Windows 服务控制管理器（SCM）启动时，`bitsrun` 会在服务上下文中运行 `keep-alive` 守护进程，并向 SCM 上报状态。日志同时写入 Windows 事件日志（来源：`Bitsrun`）以及可执行文件同目录的本地日志文件 `bitsrun_service.log`。
+
+快速设置：
+
+```powershell
+sc.exe create Bitsrun binPath= "C:\Program Files\Bitsrun\bitsrun.exe" DisplayName= "Bitsrun" start= auto
+sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
+```
+
+- 将 `bit-user.json` 放在 `bitsrun.exe` 同目录，服务将优先读取该路径的配置
+- 管理服务：`sc.exe start Bitsrun`、`sc.exe stop Bitsrun`、`sc.exe query Bitsrun`
+- 删除服务：`sc.exe stop Bitsrun` 后执行 `sc.exe delete Bitsrun`
+- 查看日志：
+  - 文件日志：与 `bitsrun.exe` 同目录的 `bitsrun_service.log`
+  - 事件日志：事件查看器 → Windows 日志 → 应用程序 → 来源 `Bitsrun`
+
+> 注意：创建与启动服务需要管理员权限，以正确注册事件日志来源。
+>
+> 详细指南：[`docs/windows-service.zh-CN.md`](docs/windows-service.zh-CN.md)
+
+## 配置与凭据
+
+将你的配置保存到 `bit-user.json`（OS 依赖的配置路径可通过 `bitsrun config-paths` 查看）。示例：
+
+```json
+{
+  "username": "<username>",
+  "password": "<password>",
+  "dm": true,
+  "poll_interval": 3600
+}
+```
+
+- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，设为 `true`
+- `poll_interval`：守护进程轮询登录请求的间隔（秒），默认 `3600`
+
+Linux / macOS 上需将此文件权限设为 `600`，否则 `bitsrun` 将拒绝读取：
+
+```console
+$ chmod 600 <path/to/bit-user.json>
+```
+
+## 相关项目
+
+- [`zu1k/srun`](https://github.com/zu1k/srun) - 深澜认证系统登录工具（Rust）
+- [`Mmx233/BitSrunLoginGo`](https://github.com/Mmx233/BitSrunLoginGo) - 深澜校园网登录脚本（Go）
+- [`vouv/srun`](https://github.com/vouv/srun) - 高效的 BIT 校园网客户端（Go）
+- [`BITNP/bitsrun`](https://github.com/BITNP/bitsrun) - Python 版无界面登录/登出脚本
+
+## 许可证
+
+[MIT](./LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,7 +116,7 @@ sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
 }
 ```
 
-- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，如果你使用的设备是**普通终端**，请设为 `true`！
+- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，如果你使用的设备是**普通终端**，请设为 `true` ！
 - `poll_interval`：守护进程轮询登录请求的间隔（秒），默认 `3600`
 
 Linux / macOS 上需将此文件权限设为 `600`，否则 `bitsrun` 将拒绝读取：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,7 +116,7 @@ sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
 }
 ```
 
-- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，设为 `true`
+- `dm`：若当前设备属于“哑终端”，登出需要使用备用端点，如果你使用的设备是**普通终端**，请设为 `true`！
 - `poll_interval`：守护进程轮询登录请求的间隔（秒），默认 `3600`
 
 Linux / macOS 上需将此文件权限设为 `600`，否则 `bitsrun` 将拒绝读取：

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -1,0 +1,61 @@
+# Windows Service Setup
+
+English | [简体中文](windows-service.zh-CN.md)
+
+This document describes how to run `bitsrun` as a native Windows Service (SCM-managed), mirroring the behavior of the minimal branch.
+
+## 概述
+
+- Service name: `Bitsrun`
+- Type: Own process managed by SCM
+- Behavior: When launched by SCM, runs the `keep-alive` daemon in service context; reports status; handles stop/shutdown
+- Logging:
+  - Event Log: Source `Bitsrun`, under “Application”
+  - Local file: `bitsrun_service.log` next to the executable
+- Config file: Prefer `bit-user.json` from the executable directory
+
+```json
+{
+  "username": "<username>",
+  "password": "<password>",
+  "dm": false,
+  "poll_interval": 3600
+}
+```
+
+Run as Administrator in PowerShell:
+
+```powershell
+sc.exe create Bitsrun binPath= "C:\Program Files\Bitsrun\bitsrun.exe" DisplayName= "Bitsrun" start= auto
+sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
+```
+
+Notes:
+- `binPath` must be an absolute path to `bitsrun.exe`
+- `start= auto` starts the service on boot
+
+Manage:
+
+```powershell
+sc.exe start Bitsrun
+sc.exe stop Bitsrun
+sc.exe query Bitsrun
+```
+
+```powershell
+sc.exe stop Bitsrun
+sc.exe delete Bitsrun
+```
+
+Logs and troubleshooting:
+- File: `bitsrun_service.log` beside `bitsrun.exe`
+- Event Log: Event Viewer → Windows Logs → Application → Source `Bitsrun`
+- The first install/start requires Administrator privileges to properly register the Event Log source
+
+CLI vs Service:
+- CLI mode: When started manually from a terminal, `bitsrun` works as usual
+- Service mode: When launched by SCM, it runs the `keep-alive` daemon automatically
+
+References and Compatibility:
+- Reference changes: `PR_windows_service_minimal.md`, service entry `src/windows_service.rs:267`, main dispatcher `src/main.rs:53`
+- Non-Windows platforms unaffected (`cfg(windows)` guarded)

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -4,7 +4,7 @@ English | [简体中文](windows-service.zh-CN.md)
 
 This document describes how to run `bitsrun` as a native Windows Service (SCM-managed), mirroring the behavior of the minimal branch.
 
-## 概述
+## Overview
 
 - Service name: `Bitsrun`
 - Type: Own process managed by SCM

--- a/docs/windows-service.zh-CN.md
+++ b/docs/windows-service.zh-CN.md
@@ -1,0 +1,74 @@
+# Windows 服务设置
+
+[English](windows-service.md) | 简体中文
+
+本文档介绍如何在 Windows 上将 `bitsrun` 作为原生 Windows 服务运行。
+
+## 概述
+
+- 服务名称：`Bitsrun`
+- 服务类型：独立进程（由 SCM 管理）
+- 行为：由 SCM 启动时在服务上下文中运行 `keep-alive` 守护进程；停止/关机时能优雅退出并上报状态
+- 日志：
+  - 事件日志：`应用程序` 日志，来源为 `Bitsrun`
+  - 本地日志文件：与可执行文件同目录，文件名 `bitsrun_service.log`
+- 配置文件位置：优先从可执行文件所在目录寻找 `bit-user.json`
+
+## 前置条件
+
+- 已安装 `bitsrun.exe`，例如放在 `C:\Program Files\Bitsrun\bitsrun.exe`
+- 在上述目录放置配置文件 `bit-user.json`（与可执行文件同目录），内容示例：
+
+```json
+{
+  "username": "<username>",
+  "password": "<password>",
+  "dm": false,
+  "poll_interval": 3600
+}
+```
+
+## 安装服务
+
+以管理员身份打开 PowerShell 或 CMD，执行：
+
+```powershell
+sc.exe create Bitsrun binPath= "C:\Program Files\Bitsrun\bitsrun.exe" DisplayName= "Bitsrun" start= auto
+sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
+```
+
+说明：
+- `binPath` 指向 `bitsrun.exe` 的绝对路径
+- `start= auto` 表示系统启动时自动启动服务
+- 创建后可在“服务”管理器中看到 `Bitsrun`
+
+## 启动与管理
+
+```powershell
+sc.exe start Bitsrun
+sc.exe stop Bitsrun
+sc.exe query Bitsrun
+```
+
+如需删除服务：
+
+```powershell
+sc.exe stop Bitsrun
+sc.exe delete Bitsrun
+```
+
+## 日志与排错
+
+- 文件日志：`bitsrun_service.log` 位于 `bitsrun.exe` 同目录，记录关键事件（启动、守护进程初始化、停止等）
+- 事件日志：打开“事件查看器”→“Windows 日志”→“应用程序”，筛选来源为 `Bitsrun`
+- 初次安装时，事件日志来源注册需要管理员权限；若事件日志无记录，请确认以管理员身份创建服务并启动一次
+
+## 与 CLI 的关系
+
+- 手动在终端运行 `bitsrun`（非 SCM 启动）时，程序按 CLI 方式工作（`login`/`logout`/`status`/`keep-alive` 等）
+- 由 SCM 启动时，程序作为服务运行，内部自动进入守护模式，无需额外参数
+
+## 参考与兼容性
+
+- 参考改动：`PR_windows_service_minimal.md`，以及源码中的服务入口 `src/windows_service.rs:267` 与主入口调度 `src/main.rs:53`
+- 非 Windows 平台不受影响；所有服务相关代码使用条件编译 `cfg(windows)`


### PR DESCRIPTION

## 背景
- 补充中文文档，完善 Windows 服务部署与运维说明，提升跨平台可用性
- 英文 README 增加 “Windows Service” 章节，便于英文用户快速上手
- 参考 #17 的实现，保持行为一致

## 主要改动
- 新增中文文档：`README.zh-CN.md`
- 新增 Windows 服务指南：`docs/windows-service.md`
- 更新英文文档：`README.md` 增加 “Windows Service (Windows only)” 章节与中文/Windows 文档链接

## Windows 服务快速指引

安装（管理员 PowerShell）：

```powershell
sc.exe create Bitsrun binPath= "C:\Program Files\Bitsrun\bitsrun.exe" DisplayName= "Bitsrun" start= auto
sc.exe description Bitsrun "Bitsrun keep-alive service for BIT gateway"
```

管理：

```powershell
sc.exe start Bitsrun
sc.exe stop Bitsrun
sc.exe query Bitsrun
```

删除：

```powershell
sc.exe stop Bitsrun
sc.exe delete Bitsrun
```

配置：
- 将 `bit-user.json` 放在 `bitsrun.exe` 同目录，服务会优先在此查找

日志与排错：
- 文件日志：`bitsrun_service.log`（与 `bitsrun.exe` 同目录）
- 事件日志：事件查看器 → Windows 日志 → 应用程序 → 来源 `Bitsrun`
- 首次创建/启动服务需管理员权限以注册事件日志来源

## 源码位置
- 服务调度入口：`src/windows_service.rs:267`
- 主入口服务调度：`src/main.rs:53`
- 文件日志落地：`src/service_logger.rs:169`

## 兼容性
- 非 Windows 平台不受影响（服务相关通过 `cfg(windows)` 条件编译）
- 终端直接运行保持现有 CLI 行为；由 SCM 启动自动进入服务模式

## 文件清单
- 新增：`README.zh-CN.md`
- 新增：`docs/windows-service.md`
- 新增：`docs/windows-service.zh-CN.md`
- 更新：`README.md`
